### PR TITLE
Fix: Redirect to /chat after Google Sign-In

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -122,7 +122,7 @@ export default function AuthPage() {
   const handleAuthSuccess = (userCredential: UserCredential) => {
     console.log('Auth success:', userCredential.user);
     resetFormAndErrors();
-    // router.replace('/chat'); // Use replace for navigation
+    router.replace('/chat'); // Use replace for navigation
   };
 
   const handleAuthError = (error: any) => { // Changed FirebaseError to any for broader compatibility


### PR DESCRIPTION
I uncommented the router.replace('/chat') line in the handleAuthSuccess function to ensure you are redirected to the chat page after a successful Google Sign-In using the redirect method.